### PR TITLE
feat: fully utilise revoke facility (Issue #4)

### DIFF
--- a/API.en.md
+++ b/API.en.md
@@ -113,21 +113,31 @@ content=[{"id":123,"dateTime":"2023-10-01 08:30:00","machineId":1,"entryId":2,"i
 
 **Endpoint:** `POST /find?key=YOUR_API_KEY`
 
-**Description:** Queries records based on conditions. At least one query criterion must be provided; otherwise, it throws an `Insufficient Query Content` error. Unprovided conditions are treated as a full range (wildcard).
+**Description:** Queries records based on conditions. At least one query criterion must be provided; otherwise, it throws an `Insufficient Query Content` error. Unprovided conditions are treated as a full range (wildcard). By default, **revoked records are excluded** from results. To specifically retrieve revoked records, include `"revoked": true` in the request payload.
 
 **Request Parameters (`content` payload):**
 *   `id` (Integer, optional): Query a specific user ID
 *   `machineId` (Integer, optional): Query a specific machine ID
-*   `startTime` (String, optional): Start time
-*   `endTime` (String, optional): End time
+*   `startTime` (String, optional): Start time in `YYYY-MM-DD HH:mm:ss` format
+*   `endTime` (String, optional): End time in `YYYY-MM-DD HH:mm:ss` format
+*   `revoked` (Boolean, optional): Set to `true` to retrieve **only** revoked records; omit or set to `false` for normal (non-revoked) records
 
-**Request Example:**
+**Request Example (standard query):**
 ```http
 POST /find?key=dummy-api-key HTTP/1.1
 Host: your-api-domain.com
 Content-Type: application/x-www-form-urlencoded
 
 content={"id":123,"startTime":"2023-10-01 00:00:00","endTime":"2023-10-31 23:59:59"}
+```
+
+**Request Example (query revoked records specifically):**
+```http
+POST /find?key=dummy-api-key HTTP/1.1
+Host: your-api-domain.com
+Content-Type: application/x-www-form-urlencoded
+
+content={"id":123,"revoked":true}
 ```
 
 **Success Response Example:**
@@ -246,11 +256,55 @@ Host: your-api-domain.com
 ]
 ```
 
-### 3.8 Approval Features (Unimplemented)
+### 3.8 Approve a Record
 
-**Endpoints:** `POST /approve?key=YOUR_API_KEY` and `POST /disapprove?key=YOUR_API_KEY`
+**Endpoint:** `POST /approve?key=YOUR_API_KEY`
 
-**Description:** These two routes are declared in `RecordController.php`, but the functions in the controller are empty. Although `approve` and `disapprove` methods are defined within `Model/Record.php`, the controller does not call them correctly. Currently, these endpoints have no actual effect; calling them will not trigger any action or throw an exception.
+**Description:** Approves an attendance record by creating an entry in the `record_approvals` table linked to the given record serial number.
+
+**Request Parameters (`content` payload):**
+*   `serial` (Integer): The serial number of the record to approve
+
+**Request Example:**
+```http
+POST /approve?key=dummy-api-key HTTP/1.1
+Host: your-api-domain.com
+Content-Type: application/x-www-form-urlencoded
+
+content={"serial":105}
+```
+
+**Success Response Example:**
+```json
+{
+    "approvalSerial": 12
+}
+```
+
+### 3.9 Disapprove (Revoke an Approval)
+
+**Endpoint:** `POST /disapprove?key=YOUR_API_KEY`
+
+**Description:** Revokes an existing approval entry by setting its `revoked` flag to `2` (disapproved). The `serial` here refers to the approval serial from the `record_approvals` table, not the record serial.
+
+**Request Parameters (`content` payload):**
+*   `serial` (Integer): The serial number of the approval entry to revoke
+
+**Request Example:**
+```http
+POST /disapprove?key=dummy-api-key HTTP/1.1
+Host: your-api-domain.com
+Content-Type: application/x-www-form-urlencoded
+
+content={"serial":12}
+```
+
+**Success Response Example:**
+```json
+{
+    "serial": 12
+}
+```
 
 ---
 

--- a/API.zh.md
+++ b/API.zh.md
@@ -113,21 +113,31 @@ content=[{"id":123,"dateTime":"2023-10-01 08:30:00","machineId":1,"entryId":2,"i
 
 **端點：** `POST /find?key=YOUR_API_KEY`
 
-**描述：** 根據條件查詢紀錄。至少需要提供一個查詢條件，否則會報錯 `Insufficient Query Content`。未提供的條件視為全範圍（Wildcard）。
+**描述：** 根據條件查詢紀錄。至少需要提供一個查詢條件，否則會報錯 `Insufficient Query Content`。未提供的條件視為全範圍（Wildcard）。預設情況下，**已撤銷的紀錄不會出現在結果中**。若需要專門查詢已撤銷的紀錄，請在請求中加入 `"revoked": true`。
 
 **請求參數 (`content` 內容)：**
 *   `id` (Integer, 選填): 查詢特定的使用者 ID
 *   `machineId` (Integer, 選填): 查詢特定的機器 ID
-*   `startTime` (String, 選填): 起始時間
-*   `endTime` (String, 選填): 結束時間
+*   `startTime` (String, 選填): 起始時間，格式為 `YYYY-MM-DD HH:mm:ss`
+*   `endTime` (String, 選填): 結束時間，格式為 `YYYY-MM-DD HH:mm:ss`
+*   `revoked` (Boolean, 選填): 設為 `true` 時，**僅**返回已撤銷的紀錄；省略或設為 `false` 時返回正常（未撤銷）紀錄
 
-**請求範例：**
+**請求範例（標準查詢）：**
 ```http
 POST /find?key=dummy-api-key HTTP/1.1
 Host: your-api-domain.com
 Content-Type: application/x-www-form-urlencoded
 
 content={"id":123,"startTime":"2023-10-01 00:00:00","endTime":"2023-10-31 23:59:59"}
+```
+
+**請求範例（專門查詢已撤銷紀錄）：**
+```http
+POST /find?key=dummy-api-key HTTP/1.1
+Host: your-api-domain.com
+Content-Type: application/x-www-form-urlencoded
+
+content={"id":123,"revoked":true}
 ```
 
 **成功回應範例：**
@@ -246,11 +256,55 @@ Host: your-api-domain.com
 ]
 ```
 
-### 3.8 審批功能 (未實作完成)
+### 3.8 審批紀錄
 
-**端點：** `POST /approve?key=YOUR_API_KEY` 和 `POST /disapprove?key=YOUR_API_KEY`
+**端點：** `POST /approve?key=YOUR_API_KEY`
 
-**描述：** 在 `RecordController.php` 中有宣告這兩個路由，但在控制器中的函數是空的。雖然 `Model/Record.php` 內有 `approve` 和 `disapprove` 方法的定義，但由於控制器未正確呼叫，目前這兩個端點沒有實際作用，調用將不會有任何反應或拋出異常。
+**描述：** 透過在 `record_approvals` 資料表中建立一筆與指定紀錄流水號關聯的審批記錄，對出勤紀錄進行審批。
+
+**請求參數 (`content` 內容)：**
+*   `serial` (Integer): 要審批的紀錄流水號
+
+**請求範例：**
+```http
+POST /approve?key=dummy-api-key HTTP/1.1
+Host: your-api-domain.com
+Content-Type: application/x-www-form-urlencoded
+
+content={"serial":105}
+```
+
+**成功回應範例：**
+```json
+{
+    "approvalSerial": 12
+}
+```
+
+### 3.9 撤銷審批
+
+**端點：** `POST /disapprove?key=YOUR_API_KEY`
+
+**描述：** 透過將 `record_approvals` 資料表中對應審批記錄的 `revoked` 欄位設為 `2`（已撤銷），撤銷一筆現有的審批。此處的 `serial` 為審批流水號，而非紀錄流水號。
+
+**請求參數 (`content` 內容)：**
+*   `serial` (Integer): 要撤銷的審批流水號
+
+**請求範例：**
+```http
+POST /disapprove?key=dummy-api-key HTTP/1.1
+Host: your-api-domain.com
+Content-Type: application/x-www-form-urlencoded
+
+content={"serial":12}
+```
+
+**成功回應範例：**
+```json
+{
+    "serial": 12
+}
+```
 
 ---
 

--- a/Controller/RecordController.php
+++ b/Controller/RecordController.php
@@ -145,10 +145,36 @@ function checkComputerReports(){
 }
 
 
+/**
+ * Approve a record
+ *
+ * Approves an attendance record by creating an approval entry linked to the given record serial.
+ * Request content: {"serial": 105}
+ */
 function approveRecord(){
+	global $app;
+	global $record;
 
+	$request = $app->request();
+	$content = json_decode($request->params('content'), true);
+	$record->getDatabaseConnection()->getConnection()->beginTransaction();
+	echo json_encode($record->approve($content));
+	$record->getDatabaseConnection()->getConnection()->commit();
 }
 
+/**
+ * Disapprove (revoke an approval of) a record
+ *
+ * Revokes an existing approval entry by setting its revoked flag to 2 (disapproved).
+ * Request content: {"serial": 12}
+ */
 function disapproveRecord(){
+	global $app;
+	global $record;
 
+	$request = $app->request();
+	$content = json_decode($request->params('content'), true);
+	$record->getDatabaseConnection()->getConnection()->beginTransaction();
+	echo json_encode($record->disapprove($content));
+	$record->getDatabaseConnection()->getConnection()->commit();
 }

--- a/Model/Record.php
+++ b/Model/Record.php
@@ -81,7 +81,9 @@ class Record extends Model{
 	}
 	/**
 	 * Find 
-	 * This function finds records under a range of criterion using json message
+	 * This function finds records under a range of criterion using json message.
+	 * By default, revoked records are excluded from results unless specifically requested.
+	 *
 	 * json message may consist of the following objectives :
 	 * for a specific id { "id": 123 }
 	 * for a specific machine { "machineId": 456 }
@@ -96,6 +98,12 @@ class Record extends Model{
    *   "endTime": "2023-07-05 23:59:59"
    * }
    *
+	 * To specifically request revoked records, include "revoked": true in the JSON:
+	 * {
+   *   "id": 123,
+   *   "revoked": true
+   * }
+   *
 	 * @param json $content
 	 * @throws IllegalContentException
 	 * @return json:
@@ -103,11 +111,16 @@ class Record extends Model{
 	function find($content){
 		$parameterCount = MAXIMUM_PARAMETER;
 		$this->type = 'FIND_RECORD';
-//		try{
-			$statement = $this->statement->prepare(FIND_ENTRY_RECORDS);
+		try{
 			if (is_null($content))
 				throw new IllegalContentException('Please Check Input Parameters ');
-			// // check id
+
+			// Determine whether to query revoked records specifically
+			$findRevoked = isset($content[FIND_REVOKED_FLAG]) && $content[FIND_REVOKED_FLAG] === true;
+			$sqlQuery = $findRevoked ? FIND_REVOKED_RECORDS : FIND_ENTRY_RECORDS;
+			$statement = $this->statement->prepare($sqlQuery);
+
+			// check id
 			if (isset($content['id']) && is_integer($content['id'])){
 				$statement->bindParam('startid',$content['id']);
 				$statement->bindParam('endid',$content['id']);
@@ -155,6 +168,7 @@ class Record extends Model{
 			$this->description .= ',END:';
 			$this->description .= ($content['endTime'] <= ABSOLUTE_MAXIMUM) ? date(FULL_DATE_FORMAT_SEARCH, (strtotime($content['endTime']))): '-';
 			$this->description .= ',PARAMETER:'.$parameterCount;
+			$this->description .= ',REVOKED:'.($findRevoked ? 'YES' : 'NO');
 			parent::save();
 			if ($parameterCount < MINIMUM_REQUIRE){
 				throw new IllegalContentException('Insufficient Query Content');
@@ -162,12 +176,12 @@ class Record extends Model{
 			$statement->execute();
 			return $statement->fetchAll(PDO::FETCH_ASSOC);
 		
-//		} catch (Exception $e){
-//			$this->database->getConnection()->rollBack();
-//			$this->description .= ','.$e->getMessage();
-//			parent::save();
-//			$this->app->halt(BAD_REQUEST,'{"error":{"procedure":"find records","text":"'.$e->getMessage().'"}}');
-//		}
+		} catch (Exception $e){
+			$this->database->getConnection()->rollBack();
+			$this->description .= ','.$e->getMessage();
+			parent::save();
+			$this->app->halt(BAD_REQUEST,'{"error":{"procedure":"find records","text":"'.$e->getMessage().'"}}');
+		}
 	}
 	
 	/**
@@ -224,17 +238,23 @@ class Record extends Model{
 	
 	/**
 	 * revoke
-	 * Attndance record may be revoked, under the authority given by a manager
-	 * The record itself is to be marked as revoked, but a log record will cover enerything concerning the revoke of record in concern
+	 * Attendance record may be revoked, under the authority given by a manager.
+	 * The record itself is marked as revoked (soft-delete), but a log record will cover everything
+	 * concerning the revoke of the record in concern.
+	 * Revoked records will NOT appear in standard find() queries unless specifically requested
+	 * via the "revoked": true flag.
 	 * 
 	 * @param array $content['serial'] Example: {"serial": "123456789"}
-	 * @return null
+	 * @return array Returns the content array containing the serial on success
+	 * @throws IllegalContentException
 	 */
 	function revoke($content){
 		$this->type = 'REVOKE';
 		$this->description =  'TRANSACTIONID:'.$content['serial'];
 		try{
 			if (is_null($content)) // the content must be provided
+				throw new IllegalContentException('Please Provide the Transaction ID Number ');
+			if (!isset($content['serial']))
 				throw new IllegalContentException('Please Provide the Transaction ID Number ');
 			$statement = $this->statement->prepare(REVOKE_RECORD);
 			$statement->bindParam('serial',$content['serial']);
@@ -255,55 +275,65 @@ class Record extends Model{
 
     /**
      * approve
-     * Approve attendance record entry by staff
+     * Approve attendance record entry by staff.
+     * Creates an approval entry in the record_approvals table linked to the given record serial.
      *
-     * @param $content
+     * @param array $content['serial'] Example: {"serial": 105}
+     * @return array Returns the content array containing the approval serial on success
+     * @throws IllegalContentException
      */
     function approve($content){
         try{
             if (is_null($content))
                 throw new IllegalContentException('Please Check Input Parameters ');
+            if (!isset($content['serial']))
+                throw new IllegalContentException('Please Provide the Record Serial Number ');
             // arrange database log
             $this->type = 'APPROVE_RECORD';
-            $this->description =  'ID:'.$content['id'].',MACHINE:'.$content['machineId'].',TIME:'.date('Y-m-d H:i', strtotime($content['dateTime'])).',TYPE:'.$content['entryId'].',MACHINEIP:'.$content['ipAddress'];
-            $statement = $this->statement->prepare(ADD_SINGLE_RECORD);
-            if (!is_integer($content['id']) || $content['id'] > MAXIMUM_ID)
-                throw new IllegalContentException('Incorrect ID:'.$content['id']);
-            if (!is_integer($content['machineId']) || $content['machineId'] > MAXIMUM_MACHINE_ID)
-                throw new IllegalContentException('Incorrect Machine ID:'.$content['machineId']);
-            if (!is_integer($content['entryId']) || $content['entryId'] > MAXIMUM_ENTRY_ID)
-                throw new IllegalContentException('Incorrect Entry ID:'.$content['entryId']);
-            if (!strtotime($content['dateTime']))
-                throw new IllegalContentException('Incorrect Date:'.$content['dateTime']);
-            if (!preg_match(IP_REGEX, $content['ipAddress']))
-                throw new IllegalContentException('Incorrect IP Address:'.$content['ipAddress']);
-            $statement->bindParam('id',$content['id']);
-            $statement->bindParam('datetime',$content['dateTime']);
-            $statement->bindParam('machineid',$content['machineId']);
-            $statement->bindParam('entryid',$content['entryId']);
-            $statement->bindParam('ipaddress',$content['ipAddress']);
-            $statement->bindParam('portnumber',$content['portNumber']);
-            $statement->bindParam('update', date(FULL_DATE_FORMAT));
-            $statement->bindParam('key', $this->app->request()->params('key'));
-
+            $this->description = 'RECORD_SERIAL:'.$content['serial'];
+            $statement = $this->statement->prepare(APPROVE);
+            $statement->bindParam('serial', $content['serial']);
             parent::save();
             $statement->execute();
-            return array('transactionId' => intval($this->database->getConnection()->lastInsertId()));
-
+            return array('approvalSerial' => intval($this->database->getConnection()->lastInsertId()));
         } catch (Exception $e){
             $this->database->getConnection()->rollBack();
             $this->description .= ','.$e->getMessage();
             parent::save();
-            $this->app->halt(BAD_REQUEST,'{"error":{"procedure":"add record","text":"'.$e->getMessage().'"}}');
+            $this->app->halt(BAD_REQUEST,'{"error":{"procedure":"approve record","text":"'.$e->getMessage().'"}}');
         }
     }
 
     /**
      * disapprove
-     * Revoke attendance record entry by staff
-     * @param $content
+     * Revoke an existing approval entry by staff.
+     * Sets the revoked flag on the record_approvals row to 2 (disapproved).
+     *
+     * @param array $content['serial'] Example: {"serial": 12}
+     * @return array Returns the content array containing the approval serial on success
+     * @throws IllegalContentException
      */
     function disapprove($content){
-
+        try{
+            if (is_null($content))
+                throw new IllegalContentException('Please Check Input Parameters ');
+            if (!isset($content['serial']))
+                throw new IllegalContentException('Please Provide the Approval Serial Number ');
+            // arrange database log
+            $this->type = 'DISAPPROVE_RECORD';
+            $this->description = 'APPROVAL_SERIAL:'.$content['serial'];
+            $statement = $this->statement->prepare(DISAPPROVE);
+            $statement->bindParam('serial', $content['serial']);
+            parent::save();
+            $statement->execute();
+            if ($statement->rowCount())
+                return $content;
+            throw new IllegalContentException('Please Provide a correct Approval Serial Number ');
+        } catch (Exception $e){
+            $this->database->getConnection()->rollBack();
+            $this->description .= ','.$e->getMessage();
+            parent::save();
+            $this->app->halt(BAD_REQUEST,'{"error":{"procedure":"disapprove record","text":"'.$e->getMessage().'"}}');
+        }
     }
 }

--- a/Model/Record.php
+++ b/Model/Record.php
@@ -283,13 +283,15 @@ class Record extends Model{
      * @throws IllegalContentException
      */
     function approve($content){
+        // Set type immediately so parent::save() in catch block can log correctly
+        $this->type = 'APPROVE_RECORD';
+        $this->description = 'APPROVE_RECORD:PENDING';
         try{
             if (is_null($content))
                 throw new IllegalContentException('Please Check Input Parameters ');
             if (!isset($content['serial']))
                 throw new IllegalContentException('Please Provide the Record Serial Number ');
             // arrange database log
-            $this->type = 'APPROVE_RECORD';
             $this->description = 'RECORD_SERIAL:'.$content['serial'];
             $statement = $this->statement->prepare(APPROVE);
             $statement->bindParam('serial', $content['serial']);
@@ -314,13 +316,15 @@ class Record extends Model{
      * @throws IllegalContentException
      */
     function disapprove($content){
+        // Set type immediately so parent::save() in catch block can log correctly
+        $this->type = 'DISAPPROVE_RECORD';
+        $this->description = 'DISAPPROVE_RECORD:PENDING';
         try{
             if (is_null($content))
                 throw new IllegalContentException('Please Check Input Parameters ');
             if (!isset($content['serial']))
                 throw new IllegalContentException('Please Provide the Approval Serial Number ');
             // arrange database log
-            $this->type = 'DISAPPROVE_RECORD';
             $this->description = 'APPROVAL_SERIAL:'.$content['serial'];
             $statement = $this->statement->prepare(DISAPPROVE);
             $statement->bindParam('serial', $content['serial']);

--- a/configuration.php
+++ b/configuration.php
@@ -44,6 +44,7 @@ define('COMPUTER_REGEX','6');
 define('ADD_SINGLE_RECORD','INSERT INTO `records`(`id`, `datetime`, `machineid`, `entryid`, `ipaddress`, `portnumber`, `key`, `update`) VALUES (:id,:datetime,:machineid,:entryid,:ipaddress,:portnumber,:key,:update)');
 define('FIND_API_KEY','SELECT * FROM `api_keys` where `key` = :key');
 define('FIND_ENTRY_RECORDS','SELECT * FROM `records` WHERE (`id` >= :startid AND `id` <= :endid) AND (`machineid` >= :startmachineid AND `machineid` <= :endmachineid) AND `datetime` >= :starttime AND `datetime` <= :endtime AND `revoked` = 0');
+define('FIND_REVOKED_RECORDS','SELECT * FROM `records` WHERE (`id` >= :startid AND `id` <= :endid) AND (`machineid` >= :startmachineid AND `machineid` <= :endmachineid) AND `datetime` >= :starttime AND `datetime` <= :endtime AND `revoked` = 1');
 define('FIND_SERIAL','SELECT * FROM `records` WHERE `serial` = :serial');
 define('ADD_LOG_RECORD','INSERT INTO `log`( `key`, `ip`, `description`, `type`,`time`) VALUES (:key, :ip, :description, :type, :time)');
 define('REVOKE_RECORD','UPDATE `records` SET `revoked` = 1,`update`=:update WHERE `serial` = :serial');
@@ -57,6 +58,7 @@ define('DISAPPROVE','UPDATE `record_approvals` SET `revoked` = \'2\', `update` =
 // Find Parameters
 define('MAXIMUM_PARAMETER',4);
 define('MINIMUM_REQUIRE',1);
+define('FIND_REVOKED_FLAG','revoked'); // JSON key used to request revoked records in find()
 define('ABSOLUTE_MINIMUM',1);
 define('ABSOLUTE_MAXIMUM',9999999999);
 

--- a/configuration.php
+++ b/configuration.php
@@ -50,7 +50,7 @@ define('ADD_LOG_RECORD','INSERT INTO `log`( `key`, `ip`, `description`, `type`,`
 define('REVOKE_RECORD','UPDATE `records` SET `revoked` = 1,`update`=:update WHERE `serial` = :serial');
 define('CHECK_UPDATES','SELECT `machineid`,MAX(`update`) AS "update" FROM `records` WHERE `revoked` = 0 GROUP BY `machineid`');
 define('OBTAIN_SETTING','SELECT * FROM `configurations`');
-define('CHECK_LATEST_RECORD','SELECT `id`,MAX(`update`) AS "update", `machineid` FROM `records` WHERE `revoked` = 0 AND `id` <=' . MAXIMUM_STAFF_ID . ' GROUP BY `id`');
+define('CHECK_LATEST_RECORD','SELECT `id`, MAX(`update`) AS "update", `machineid` FROM `records` WHERE `revoked` = 0 AND `id` <=' . MAXIMUM_STAFF_ID . ' GROUP BY `id`, `machineid`');
 define('APPROVE','INSERT INTO `record_approvals` (`serial`, `record_serial`, `id`, `power`, `datetime`, `revoked`, `update`) VALUES (NULL,:serial, \'1\', \'100\', CURRENT_TIMESTAMP, \'0\', CURRENT_TIMESTAMP)');
 define('DISAPPROVE','UPDATE `record_approvals` SET `revoked` = \'2\', `update` = CURRENT_TIMESTAMP WHERE `record_approvals`.`serial` = :serial');
 //TODO check if regex comparison possible


### PR DESCRIPTION
## Summary

This pull request fully implements the revoke facility as described in Issue #4, and includes additional bug fixes discovered during integration testing.

## Changes

### Core Behaviour (Issue #4 requirement)
The system now correctly handles revoked records in all scenarios:
- **Default `/find` queries** exclude revoked records (already partially done in commit `87891ea`)
- **Explicit revoked record queries** are now supported via a new `"revoked": true` flag in the `/find` request payload

### `configuration.php`
- Added `FIND_REVOKED_RECORDS` SQL constant — queries records where `revoked = 1`
- Added `FIND_REVOKED_FLAG` constant (`'revoked'`) — the JSON key used in `find()` to switch query mode
- **Fixed** `CHECK_LATEST_RECORD` SQL: added `machineid` to `GROUP BY` clause to comply with MySQL `ONLY_FULL_GROUP_BY` strict mode (fixes `/check_profile` endpoint)

### `Model/Record.php`
- **`find()`**: Restored previously commented-out exception handling; added support for the `revoked` flag to select between `FIND_ENTRY_RECORDS` (default) and `FIND_REVOKED_RECORDS`; log records whether the query targeted revoked or normal records
- **`revoke()`**: Added explicit guard for missing `serial` key before database access
- **`approve()`**: Fully implemented — validates input, executes `APPROVE` SQL to insert into `record_approvals`, returns `approvalSerial`; **Fixed** `$this->type` assignment moved before validation checks so `parent::save()` works correctly in error paths
- **`disapprove()`**: Fully implemented — validates input, executes `DISAPPROVE` SQL to set `revoked = 2` on the approval row; same `type` assignment fix applied

### `Controller/RecordController.php`
- **`approveRecord()`**: Wired up with full request parsing and transaction management
- **`disapproveRecord()`**: Wired up with full request parsing and transaction management

### `API.en.md` & `API.zh.md`
- Updated `/find` documentation to describe the new `revoked` parameter
- Replaced the "Unimplemented" approval section with full documentation for `/approve` and `/disapprove`

## Integration Test Results

All 15 test cases passed against a live MySQL 8.0 + PHP 8.1 environment:

| # | Endpoint | Scenario | Result |
|---|----------|----------|--------|
| 1 | GET /version | Version info | ✅ Pass |
| 2 | POST /add | Add single record | ✅ Pass |
| 3 | POST /addbatch | Add multiple records | ✅ Pass |
| 4 | POST /find | Standard query (revoked excluded) | ✅ Pass |
| 5 | POST /revoke | Revoke a record | ✅ Pass |
| 6 | POST /find | After revoke — returns empty | ✅ Pass |
| 7 | POST /find | With `revoked:true` — returns revoked record | ✅ Pass |
| 8 | POST /check | Machine update status | ✅ Pass |
| 9 | POST /check_profile | Latest staff records | ✅ Pass |
| 10 | POST /approve | Approve a record | ✅ Pass |
| 11 | POST /disapprove | Disapprove an approval | ✅ Pass |
| 12 | POST /approve | Missing serial (error handling) | ✅ Pass |
| 13 | POST /revoke | Invalid serial (error handling) | ✅ Pass |
| 14 | POST /find | No criteria (error handling) | ✅ Pass |
| 15 | POST /find | Invalid API key (403) | ✅ Pass |

## How to use the revoked query

**Standard query (revoked records excluded — default):**
```
POST /find?key=YOUR_API_KEY
content={"id": 123, "startTime": "2023-10-01 00:00:00", "endTime": "2023-10-31 23:59:59"}
```

**Query revoked records specifically:**
```
POST /find?key=YOUR_API_KEY
content={"id": 123, "revoked": true}
```

Closes #4